### PR TITLE
Run specs once a day

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -1,0 +1,28 @@
+name: Health check
+on:
+  schedule:
+    - cron: '0 8 * * *' # Run once a day at 8am UTC
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['10', '12', '14']
+    name: Node ${{ matrix.node }} Test
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install Node Modules
+        run: npm install
+      - name: Build package
+        run: npm run build
+      - name: Run tests
+        env:
+          SANDBOX_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
+        run: npm test

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -1,7 +1,7 @@
 name: Health check
 on:
   schedule:
-    - cron: '0 8 * * *' # Run once a day at 8am UTC
+    - cron: '0 9 * * * America/Los_Angeles'
 
 jobs:
   build-and-test:
@@ -26,3 +26,16 @@ jobs:
         env:
           SANDBOX_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
         run: npm test
+
+  failure-notification:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: exit 1
+      - name: Health check failure
+        if: always()
+        uses: kpritam/slack-job-status-action@v1
+        with:
+          job-status: ${{ job.status }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: github-actions


### PR DESCRIPTION
### What

- Building the package and running the tests once a day 
- Alerting in slack if the job fails

### Why

So that we catch drifts between our API and the SDK's early and often. 

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
