### PR TITLE
adds patch_fee_cents_usd field

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,6 @@
 
 - [ ] Have you added an integration test for the changes?
 - [ ] Have you built the gem locally and made queries against it successfully?
+- [ ] Did you update the changelog?
+- [ ] Did you bump the package version?
+- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2020-09-24
+
+### Added
+
+- `patch_fee_cents_usd` `integer` field to `orders`
+
+## Changed
+
+- `price_cents_usd` type changed from `string` to `integer`
+
 ## [1.2.2] - 2020-09-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2020-09-24
+## [1.2.3] - 2020-09-28
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `patch_fee_cents_usd` `integer` field to `orders`
-
-## Changed
-
-- `price_cents_usd` type changed from `string` to `integer`
+- `patch_fee_cents_usd` field to `orders`
 
 ## [1.2.2] - 2020-09-18
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+SHELL = /bin/bash
+
+build:
+	npx prettier --write . && \
+	npm run build
+
+test:
+	npm run test
+
+.PHONY: build test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Javascript wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.3.0",
+  "version": "1.2.3",
   "description": "Javascript wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/model/Order.js
+++ b/src/model/Order.js
@@ -16,6 +16,7 @@ class Order {
     state,
     allocationState,
     priceCentsUsd,
+    patchFeeCentsUsd,
     allocations,
     metadata
   ) {
@@ -27,6 +28,7 @@ class Order {
       state,
       allocationState,
       priceCentsUsd,
+      patchFeeCentsUsd,
       allocations,
       metadata
     );
@@ -40,6 +42,7 @@ class Order {
     state,
     allocationState,
     priceCentsUsd,
+    patchFeeCentsUsd,
     allocations,
     metadata
   ) {
@@ -49,6 +52,7 @@ class Order {
     obj['state'] = state;
     obj['allocation_state'] = allocationState;
     obj['price_cents_usd'] = priceCentsUsd;
+    obj['patch_fee_cents_usd'] = patchFeeCentsUsd;
     obj['allocations'] = allocations;
     obj['metadata'] = metadata;
   }
@@ -86,7 +90,14 @@ class Order {
       if (data.hasOwnProperty('price_cents_usd')) {
         obj['price_cents_usd'] = ApiClient.convertToType(
           data['price_cents_usd'],
-          'String'
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('patch_fee_cents_usd')) {
+        obj['patch_fee_cents_usd'] = ApiClient.convertToType(
+          data['patch_fee_cents_usd'],
+          'Number'
         );
       }
 
@@ -115,6 +126,8 @@ Order.prototype['state'] = undefined;
 Order.prototype['allocation_state'] = undefined;
 
 Order.prototype['price_cents_usd'] = undefined;
+
+Order.prototype['patch_fee_cents_usd'] = undefined;
 
 Order.prototype['allocations'] = undefined;
 

--- a/src/model/Order.js
+++ b/src/model/Order.js
@@ -90,14 +90,14 @@ class Order {
       if (data.hasOwnProperty('price_cents_usd')) {
         obj['price_cents_usd'] = ApiClient.convertToType(
           data['price_cents_usd'],
-          'Number'
+          'String'
         );
       }
 
       if (data.hasOwnProperty('patch_fee_cents_usd')) {
         obj['patch_fee_cents_usd'] = ApiClient.convertToType(
           data['patch_fee_cents_usd'],
-          'Number'
+          'String'
         );
       }
 

--- a/src/model/Photo.js
+++ b/src/model/Photo.js
@@ -8,11 +8,13 @@
 import ApiClient from '../ApiClient';
 
 class Photo {
-  constructor() {
-    Photo.initialize(this);
+  constructor(url) {
+    Photo.initialize(this, url);
   }
 
-  static initialize(obj) {}
+  static initialize(obj, url) {
+    obj['url'] = url;
+  }
 
   static constructFromObject(data, obj) {
     if (data) {

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -25,8 +25,8 @@ describe('Orders Integration', function () {
 
     const placeOrderResponse = await patch.orders.placeOrder(orderId);
     expect(placeOrderResponse.data.state).to.equal('placed');
-    expect(placeOrderResponse.data.price_cents_usd).to.equal(1);
-    expect(placeOrderResponse.data.patch_fee_cents_usd).to.equal(1);
+    expect(placeOrderResponse.data.price_cents_usd).to.equal('1.0');
+    expect(placeOrderResponse.data.patch_fee_cents_usd).to.equal('1.0');
   });
 
   it('supports cancelling orders in a `draft` state', async function () {

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -26,7 +26,7 @@ describe('Orders Integration', function () {
     const placeOrderResponse = await patch.orders.placeOrder(orderId);
     expect(placeOrderResponse.data.state).to.equal('placed');
     expect(placeOrderResponse.data.price_cents_usd).to.equal('1.0');
-    expect(placeOrderResponse.data.patch_fee_cents_usd).to.equal('1.0');
+    expect(placeOrderResponse.data.patch_fee_cents_usd).to.equal('0.0');
   });
 
   it('supports cancelling orders in a `draft` state', async function () {

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -25,6 +25,8 @@ describe('Orders Integration', function () {
 
     const placeOrderResponse = await patch.orders.placeOrder(orderId);
     expect(placeOrderResponse.data.state).to.equal('placed');
+    expect(placeOrderResponse.data.price_cents_usd).to.equal(1);
+    expect(placeOrderResponse.data.patch_fee_cents_usd).to.equal(1);
   });
 
   it('supports cancelling orders in a `draft` state', async function () {


### PR DESCRIPTION
[related to [patch-180](https://github.com/patch-technology/patch/pull/180)]

### What

- adds `patch_fee_cents_usd` field to orders
- adds a build makefile to make it easier to lint and build the sdk code

### Why

- to allow integrators to pass the patch fee to their users

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [x] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
