### PR TITLE
order price creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2020-10-14
+
+### Added
+
+- `total_price_cents_usd` field to `orders`
+- allows users to create an order by total price
+
+### Changed
+
+- order creation requires either `mass_g` or `total_price_cents_usd`, but not both
+
 ## [1.2.3] - 2020-09-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ var patch = require('@patch-technology/patch').default('key_test_1234');
 
 ### Orders
 
-In Patch, orders represent a purchase of carbon offsets or negative emissions by mass. 
-Place orders directly if you know the amount of carbon dioxide you would like to sequester. 
+In Patch, orders represent a purchase of carbon offsets or negative emissions by mass.
+Place orders directly if you know the amount of carbon dioxide you would like to sequester.
 If you do not know how much to purchase, use an estimate.
-You can also create an order with a maximum desired price, and we'll allocate enough mass to 
+You can also create an order with a maximum desired price, and we'll allocate enough mass to
 fulfill the order for you.
 
 [API Reference](https://docs.usepatch.com/#/?id=orders)
@@ -56,31 +56,32 @@ fulfill the order for you.
 #### Examples
 
 ```javascript
-// Create an order - you can create an order with either mass or total price
+// Create an order - you can create an order
+// providing either mass_g or total_price_cents_usd, but not both
 
 // Create order with mass
-const mass = 1000000 // Pass in the mass in grams (i.e. 1 metric tonne)
-patch.orders.createOrder({ mass_g: mass })
+const mass = 1000000; // Pass in the mass in grams (i.e. 1 metric tonne)
+patch.orders.createOrder({ mass_g: mass });
 
 // Create an order with a maximum total price
-const totalPriceCentsUSD = 500 // Pass in the total price in cents (i.e. 5 dollars)
-patch.orders.createOrder({ total_price_cents_usd: totalPriceCentsUSD })
+const totalPriceCentsUSD = 500; // Pass in the total price in cents (i.e. 5 dollars)
+patch.orders.createOrder({ total_price_cents_usd: totalPriceCentsUSD });
 
 // Retrieve an order
-orderId = 'ord_test_1234' // Pass in the order's id
-patch.orders.retrieveOrder(orderId)
+orderId = 'ord_test_1234'; // Pass in the order's id
+patch.orders.retrieveOrder(orderId);
 
 // Place an order
-const orderId = 'ord_test_1234' // Pass in the order's id
-patch.orders.placeOrder(orderId)
+const orderId = 'ord_test_1234'; // Pass in the order's id
+patch.orders.placeOrder(orderId);
 
 // Cancel an order
-const orderId = 'ord_test_1234' // Pass in the order's id
-patch.orders.cancelOrder(orderId)
+const orderId = 'ord_test_1234'; // Pass in the order's id
+patch.orders.cancelOrder(orderId);
 
 // Retrieve a list of orders
-const page = 1 // Pass in which page of orders you'd like
-patch.orders.retrieveOrders({ page })
+const page = 1; // Pass in which page of orders you'd like
+patch.orders.retrieveOrders({ page });
 ```
 
 ### Estimates

--- a/README.md
+++ b/README.md
@@ -45,22 +45,28 @@ var patch = require('@patch-technology/patch').default('key_test_1234');
 
 ### Orders
 
-In Patch, orders represent a purchase of carbon offsets or negative emissions by mass. Place orders directly if you know the amount of carbon dioxide you would like to sequester. If you do not know how much to purchase, use an estimate.
+In Patch, orders represent a purchase of carbon offsets or negative emissions by mass. 
+Place orders directly if you know the amount of carbon dioxide you would like to sequester. 
+If you do not know how much to purchase, use an estimate.
+You can also create an order with a maximum desired price, and we'll allocate enough mass to 
+fulfill the order for you.
 
 [API Reference](https://docs.usepatch.com/#/?id=orders)
 
 #### Examples
 
 ```javascript
-// Create an order
+// Create an order - you can create an order with either mass or total price
+
+// Create order with mass
 const mass = 1000000 // Pass in the mass in grams (i.e. 1 metric tonne)
 patch.orders.createOrder({ mass_g: mass })
 
-// Create an order with maximum total price
+// Create an order with a maximum total price
 const totalPriceCentsUSD = 500 // Pass in the total price in cents (i.e. 5 dollars)
 patch.orders.createOrder({ total_price_cents_usd: totalPriceCentsUSD })
 
-# Retrieve an order
+// Retrieve an order
 orderId = 'ord_test_1234' // Pass in the order's id
 patch.orders.retrieveOrder(orderId)
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ In Patch, orders represent a purchase of carbon offsets or negative emissions by
 const mass = 1000000 // Pass in the mass in grams (i.e. 1 metric tonne)
 patch.orders.createOrder({ mass_g: mass })
 
+// Create an order with maximum total price
+const totalPriceCentsUSD = 500 // Pass in the total price in cents (i.e. 5 dollars)
+patch.orders.createOrder({ total_price_cents_usd: totalPriceCentsUSD })
+
 # Retrieve an order
 orderId = 'ord_test_1234' // Pass in the order's id
 patch.orders.retrieveOrder(orderId)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This will create a `node_modules` directory in your test repository which will s
 ```
 $ node
 > const Patch = require('@patch-technology/patch')
-> Patch.default('<PATCH_API_KEY>').projects.retrieveProjects().then((response) => console.log(response))
+> Patch.default(process.env.SANDBOX_API_KEY).projects.retrieveProjects().then((response) => console.log(response))
 ```
 
 ### Run the specs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Javascript wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/model/CreateOrderRequest.js
+++ b/src/model/CreateOrderRequest.js
@@ -8,13 +8,11 @@
 import ApiClient from '../ApiClient';
 
 class CreateOrderRequest {
-  constructor(massG) {
-    CreateOrderRequest.initialize(this, massG);
+  constructor() {
+    CreateOrderRequest.initialize(this);
   }
 
-  static initialize(obj, massG) {
-    obj['mass_g'] = massG;
-  }
+  static initialize(obj) {}
 
   static constructFromObject(data, obj) {
     if (data) {
@@ -22,6 +20,13 @@ class CreateOrderRequest {
 
       if (data.hasOwnProperty('mass_g')) {
         obj['mass_g'] = ApiClient.convertToType(data['mass_g'], 'Number');
+      }
+
+      if (data.hasOwnProperty('total_price_cents_usd')) {
+        obj['total_price_cents_usd'] = ApiClient.convertToType(
+          data['total_price_cents_usd'],
+          'Number'
+        );
       }
 
       if (data.hasOwnProperty('project_id')) {
@@ -40,6 +45,8 @@ class CreateOrderRequest {
 }
 
 CreateOrderRequest.prototype['mass_g'] = undefined;
+
+CreateOrderRequest.prototype['total_price_cents_usd'] = undefined;
 
 CreateOrderRequest.prototype['project_id'] = undefined;
 

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -7,13 +7,21 @@ describe('Orders Integration', function () {
     const createOrderResponse = await patch.orders.createOrder({ mass_g: 100 });
     const orderId = createOrderResponse.data.id;
 
-    const retreiveOrderResponse = await patch.orders.retrieveOrder(orderId);
-    expect(retreiveOrderResponse.data.id).to.equal(orderId);
+    const retrieveOrderResponse = await patch.orders.retrieveOrder(orderId);
+    expect(retrieveOrderResponse.data.id).to.equal(orderId);
 
     const retrieveOrdersResponse = await patch.orders.retrieveOrders({
       page: 1
     });
     expect(retrieveOrdersResponse.data.length).to.be.above(0);
+  });
+
+  it('supports create orders with a total price', async function () {
+    const createOrderResponse = await patch.orders.createOrder({
+      total_price_cents_usd: 1000
+    });
+    expect(createOrderResponse.data.price_cents_usd).to.equal('6.66');
+    expect(createOrderResponse.data.patch_fee_cents_usd).to.equal('3.33');
   });
 
   it('supports placing orders in a `draft` state', async function () {

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import Patch from '../../dist/index';
 const patch = Patch(process.env.SANDBOX_API_KEY);
+const biomass_test_project_id = 'pro_test_c3a9feba769fc7a8806377266ca9ff6a';
 
 describe('Orders Integration', function () {
   it('supports create, place, cancel, retrieve and list', async function () {
@@ -18,12 +19,13 @@ describe('Orders Integration', function () {
 
   it('supports create orders with a total price', async function () {
     const createOrderResponse = await patch.orders.createOrder({
-      total_price_cents_usd: 500
+      total_price_cents_usd: 500,
+      project_id: biomass_test_project_id
     });
 
-    expect(createOrderResponse.data.price_cents_usd).to.equal('125.0');
-    expect(createOrderResponse.data.patch_fee_cents_usd).to.equal('375.0');
-    expect(createOrderResponse.data.mass_g).to.equal(1250000);
+    expect(createOrderResponse.data.price_cents_usd).to.equal('500.0');
+    expect(createOrderResponse.data.patch_fee_cents_usd).to.equal('0.0');
+    expect(createOrderResponse.data.mass_g).to.equal(5000000);
   });
 
   it('supports placing orders in a `draft` state', async function () {

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -18,10 +18,12 @@ describe('Orders Integration', function () {
 
   it('supports create orders with a total price', async function () {
     const createOrderResponse = await patch.orders.createOrder({
-      total_price_cents_usd: 1000
+      total_price_cents_usd: 500
     });
-    expect(createOrderResponse.data.price_cents_usd).to.equal('6.66');
-    expect(createOrderResponse.data.patch_fee_cents_usd).to.equal('3.33');
+
+    expect(createOrderResponse.data.price_cents_usd).to.equal('125.0');
+    expect(createOrderResponse.data.patch_fee_cents_usd).to.equal('375.0');
+    expect(createOrderResponse.data.mass_g).to.equal(1250000);
   });
 
   it('supports placing orders in a `draft` state', async function () {


### PR DESCRIPTION
### What

- adds field `total_price_cents_usd` to order creation
- allows user to create order by passing `mass_g` or `total_price_cents_usd`, but not both

### Why

- to allow users to create orders by a desired total amount

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [x] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
