### PR TITLE
Add querystring peer dep and readme instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.45 - 2020-01-07
+
+### Added
+
+- Added [`querystring`](https://www.npmjs.com/package/querystring) as a peer dependency in the package.json and an explanation in the README for when you'd need to install it manually.
+
+### Fixed
+
+- Fixed a spec that was breaking due to Patch core changes.
+
 ## [1.2.4] - 2020-10-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ const patch = Patch('key_test_1234');
 var patch = require('@patch-technology/patch').default('key_test_1234');
 ```
 
+#### Peer dependencies
+
+For environments that do not include the Node Standard Library, such as React Native, you will need to install the listed peer dependencies in order for the package to work as expected. You can install the peer dependencies by running:
+
+```
+npm install install-peers
+```
+
 ### Orders
 
 In Patch, orders represent a purchase of carbon offsets or negative emissions by mass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.2.5",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "JavaScript wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "mocha": ">=8.1.0",
     "prettier": "2.0.5"
   },
+  "peerDependencies": {
+    "querystring": "^0.2.0"
+  },
   "files": [
     "dist"
   ],

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -25,7 +25,7 @@ describe('Orders Integration', function () {
 
     expect(createOrderResponse.data.price_cents_usd).to.equal('500.0');
     expect(createOrderResponse.data.patch_fee_cents_usd).to.equal('0.0');
-    expect(createOrderResponse.data.mass_g).to.equal(5000000);
+    expect(createOrderResponse.data.mass_g).to.equal(500000);
   });
 
   it('supports placing orders in a `draft` state', async function () {


### PR DESCRIPTION
### What

Adding `querystring` as a peer dependency since it needs to be manually installed for environments where the Node Standard Library is not included. 

Adding a note to the Readme on the peer dependency and when it needs to be installed. 

### Why

The package breaks when run in environments that do not include the Node Standard  Library and users have to manually install the `querystring` package. 

### Note on test failures

The test suite is failing due to an unrelated issue - there's a PR open to fix it on the Patch core repository! 

### SDK Release Checklist

- **NA** [ ] Have you added an integration test for the changes?
- [x ] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- **NA** [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
