### PR TITLE
[v.1.3.0] Add support for Flight/Vehicle/Shipping estimates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 ### SDK Release Checklist
 
 - [ ] Have you added an integration test for the changes?
-- [ ] Have you built the gem locally and made queries against it successfully?
+- [ ] Have you built the package locally and made queries against it successfully?
 - [ ] Did you update the changelog?
 - [ ] Did you bump the package version?
 - [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.5] - 2020-02-08
+
+### Added
+
+- Adds support for creating carbon emission estimates for flights, shipping, and vehicles. See the [docs](https://docs.usepatch.com/#/?id=estimates) for more information.
+
 ## [1.2.5] - 2020-01-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.5] - 2020-02-08
+## [1.3.0] - 2020-02-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [1.3.0] - 2020-02-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,9 +101,32 @@ Estimates allow API users to get a quote for the cost of compensating a certain 
 #### Examples
 
 ```javascript
-// Create an estimate
+// Create a mass estimate
 const mass = 1000000; // Pass in the mass in grams (i.e. 1 metric tonne)
 patch.estimates.createMassEstimate({ mass_g: mass });
+
+// Create a flight estimate
+const distance_m = 9000000; // Pass in the distance traveled in meters
+patch.estimates.createFlightEstimate({ distance_m: distance_m });
+
+// Create a shipping estimate
+const distance_m = 9000000;
+// Pass in the shipping distance in meters, the transportation method, and the package mass
+patch.estimates.createFlightEstimate({
+  distance_m: distance_m,
+  transportation_method: 'air',
+  package_mass_g: 1000
+});
+
+// Create a vehicle estimate
+const distance_m = 9000000;
+// Pass in the shipping distance in meters and the model/make/year of the vehicle
+patch.estimates.createFlightEstimate({
+  distance_m: distance_m,
+  make: 'Toyota',
+  model: 'Corolla',
+  year: 1995
+});
 
 // Retrieve an estimate
 const estimateId = 'est_test_1234';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1277,25 +1277,29 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "array.prototype.map": {
       "version": "1.0.2",
@@ -1319,7 +1323,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "async-each": {
       "version": "1.0.3",
@@ -1337,7 +1342,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
@@ -1359,6 +1365,7 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -1374,6 +1381,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -1383,6 +1391,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1392,6 +1401,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1401,6 +1411,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1441,6 +1452,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -1459,6 +1471,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -1494,6 +1507,7 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -1587,6 +1601,7 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -1599,6 +1614,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -1649,6 +1665,7 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -1724,7 +1741,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -1769,6 +1787,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1783,7 +1802,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1808,6 +1828,7 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -1818,6 +1839,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1827,6 +1849,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1836,6 +1859,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1964,6 +1988,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -1979,6 +2004,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -1988,6 +2014,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -1999,6 +2026,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -2009,6 +2037,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -2020,6 +2049,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -2036,6 +2066,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -2045,6 +2076,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2054,6 +2086,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2063,6 +2096,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2072,6 +2106,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -2097,6 +2132,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -2109,6 +2145,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2165,7 +2202,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "form-data": {
       "version": "3.0.0",
@@ -2187,6 +2225,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -2242,7 +2281,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "glob": {
       "version": "7.1.6",
@@ -2326,6 +2366,7 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -2337,6 +2378,7 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -2347,6 +2389,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2517,6 +2560,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -2526,6 +2570,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2558,7 +2603,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-callable": {
       "version": "1.2.0",
@@ -2571,6 +2617,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -2580,6 +2627,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2597,6 +2645,7 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -2607,7 +2656,8 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2615,7 +2665,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -2649,6 +2700,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -2658,6 +2710,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2675,6 +2728,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
+      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -2713,13 +2767,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2731,7 +2787,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "iterate-iterator": {
       "version": "1.0.1",
@@ -2790,7 +2847,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "leven": {
       "version": "3.1.0",
@@ -2913,13 +2971,15 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
+      "optional": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -2934,6 +2994,7 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -2988,6 +3049,7 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -2998,6 +3060,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -3221,7 +3284,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nan": {
       "version": "2.14.1",
@@ -3235,6 +3299,7 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -3272,6 +3337,7 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
+      "optional": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -3283,6 +3349,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -3292,6 +3359,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3315,6 +3383,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
+      "optional": true,
       "requires": {
         "isobject": "^3.0.0"
       }
@@ -3336,6 +3405,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -3404,7 +3474,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -3486,7 +3557,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "prettier": {
       "version": "2.0.5",
@@ -3591,6 +3663,7 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -3644,13 +3717,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -3683,13 +3758,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -3701,6 +3778,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "ret": "~0.1.10"
       }
@@ -3743,6 +3821,7 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -3755,6 +3834,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -3772,6 +3852,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -3788,6 +3869,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -3797,6 +3879,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -3808,6 +3891,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -3819,6 +3903,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -3828,6 +3913,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3837,6 +3923,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3846,6 +3933,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -3859,6 +3947,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.2.0"
       },
@@ -3868,6 +3957,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3885,6 +3975,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -3915,13 +4006,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -3937,6 +4030,7 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -3947,6 +4041,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -4074,6 +4169,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -4083,6 +4179,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4094,6 +4191,7 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -4106,6 +4204,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -4150,6 +4249,7 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -4162,6 +4262,7 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -4172,6 +4273,7 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -4183,6 +4285,7 @@
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -4193,7 +4296,8 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4208,13 +4312,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.2.6",
+  "version": "1.3.5",
   "description": "JavaScript wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "JavaScript wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.3.5",
+  "version": "1.3.0",
   "description": "JavaScript wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -411,7 +411,7 @@ class ApiClient {
   hostSettings() {
     return [
       {
-        url: 'https://{defaultHost}',
+        url: 'https://api.usepatch.com',
         description: 'No description provided',
 
         variables: {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -411,7 +411,7 @@ class ApiClient {
   hostSettings() {
     return [
       {
-        url: 'https://api.usepatch.com',
+        url: 'https://{defaultHost}',
         description: 'No description provided',
 
         variables: {

--- a/src/api/EstimatesApi.js
+++ b/src/api/EstimatesApi.js
@@ -6,6 +6,7 @@
  */
 
 import ApiClient from '../ApiClient';
+import CreateFlightEstimateRequest from '../model/CreateFlightEstimateRequest';
 import CreateMassEstimateRequest from '../model/CreateMassEstimateRequest';
 import ErrorResponse from '../model/ErrorResponse';
 import EstimateListResponse from '../model/EstimateListResponse';
@@ -14,6 +15,10 @@ import EstimateResponse from '../model/EstimateResponse';
 export default class EstimatesApi {
   constructor(apiClient) {
     this.apiClient = apiClient || ApiClient.instance;
+    this.createFlightEstimate = this.createFlightEstimate.bind(this);
+    this.createFlightEstimateWithHttpInfo = this.createFlightEstimateWithHttpInfo.bind(
+      this
+    );
     this.createMassEstimate = this.createMassEstimate.bind(this);
     this.createMassEstimateWithHttpInfo = this.createMassEstimateWithHttpInfo.bind(
       this
@@ -26,6 +31,48 @@ export default class EstimatesApi {
     this.retrieveEstimatesWithHttpInfo = this.retrieveEstimatesWithHttpInfo.bind(
       this
     );
+  }
+
+  createFlightEstimateWithHttpInfo(createFlightEstimateRequest) {
+    let postBody = createFlightEstimateRequest;
+
+    // verify the required parameter 'createFlightEstimateRequest' is set
+    if (
+      createFlightEstimateRequest === undefined ||
+      createFlightEstimateRequest === null
+    ) {
+      throw new Error(
+        "Missing the required parameter 'createFlightEstimateRequest' when calling createFlightEstimate"
+      );
+    }
+
+    let pathParams = {};
+    let queryParams = {};
+    let headerParams = {};
+    let formParams = {};
+
+    let authNames = ['bearer_auth'];
+    let contentTypes = ['application/json'];
+    let accepts = ['application/json'];
+    let returnType = EstimateResponse;
+
+    return this.apiClient.callApi(
+      '/v1/estimates/flight',
+      'POST',
+      pathParams,
+      queryParams,
+      headerParams,
+      formParams,
+      postBody,
+      authNames,
+      contentTypes,
+      accepts,
+      returnType
+    );
+  }
+
+  createFlightEstimate(createFlightEstimateRequest) {
+    return this.createFlightEstimateWithHttpInfo(createFlightEstimateRequest);
   }
 
   createMassEstimateWithHttpInfo(createMassEstimateRequest) {

--- a/src/api/EstimatesApi.js
+++ b/src/api/EstimatesApi.js
@@ -8,6 +8,8 @@
 import ApiClient from '../ApiClient';
 import CreateFlightEstimateRequest from '../model/CreateFlightEstimateRequest';
 import CreateMassEstimateRequest from '../model/CreateMassEstimateRequest';
+import CreateShippingEstimateRequest from '../model/CreateShippingEstimateRequest';
+import CreateVehicleEstimateRequest from '../model/CreateVehicleEstimateRequest';
 import ErrorResponse from '../model/ErrorResponse';
 import EstimateListResponse from '../model/EstimateListResponse';
 import EstimateResponse from '../model/EstimateResponse';
@@ -21,6 +23,14 @@ export default class EstimatesApi {
     );
     this.createMassEstimate = this.createMassEstimate.bind(this);
     this.createMassEstimateWithHttpInfo = this.createMassEstimateWithHttpInfo.bind(
+      this
+    );
+    this.createShippingEstimate = this.createShippingEstimate.bind(this);
+    this.createShippingEstimateWithHttpInfo = this.createShippingEstimateWithHttpInfo.bind(
+      this
+    );
+    this.createVehicleEstimate = this.createVehicleEstimate.bind(this);
+    this.createVehicleEstimateWithHttpInfo = this.createVehicleEstimateWithHttpInfo.bind(
       this
     );
     this.retrieveEstimate = this.retrieveEstimate.bind(this);
@@ -115,6 +125,92 @@ export default class EstimatesApi {
 
   createMassEstimate(createMassEstimateRequest) {
     return this.createMassEstimateWithHttpInfo(createMassEstimateRequest);
+  }
+
+  createShippingEstimateWithHttpInfo(createShippingEstimateRequest) {
+    let postBody = createShippingEstimateRequest;
+
+    // verify the required parameter 'createShippingEstimateRequest' is set
+    if (
+      createShippingEstimateRequest === undefined ||
+      createShippingEstimateRequest === null
+    ) {
+      throw new Error(
+        "Missing the required parameter 'createShippingEstimateRequest' when calling createShippingEstimate"
+      );
+    }
+
+    let pathParams = {};
+    let queryParams = {};
+    let headerParams = {};
+    let formParams = {};
+
+    let authNames = ['bearer_auth'];
+    let contentTypes = ['application/json'];
+    let accepts = ['application/json'];
+    let returnType = EstimateResponse;
+
+    return this.apiClient.callApi(
+      '/v1/estimates/shipping',
+      'POST',
+      pathParams,
+      queryParams,
+      headerParams,
+      formParams,
+      postBody,
+      authNames,
+      contentTypes,
+      accepts,
+      returnType
+    );
+  }
+
+  createShippingEstimate(createShippingEstimateRequest) {
+    return this.createShippingEstimateWithHttpInfo(
+      createShippingEstimateRequest
+    );
+  }
+
+  createVehicleEstimateWithHttpInfo(createVehicleEstimateRequest) {
+    let postBody = createVehicleEstimateRequest;
+
+    // verify the required parameter 'createVehicleEstimateRequest' is set
+    if (
+      createVehicleEstimateRequest === undefined ||
+      createVehicleEstimateRequest === null
+    ) {
+      throw new Error(
+        "Missing the required parameter 'createVehicleEstimateRequest' when calling createVehicleEstimate"
+      );
+    }
+
+    let pathParams = {};
+    let queryParams = {};
+    let headerParams = {};
+    let formParams = {};
+
+    let authNames = ['bearer_auth'];
+    let contentTypes = ['application/json'];
+    let accepts = ['application/json'];
+    let returnType = EstimateResponse;
+
+    return this.apiClient.callApi(
+      '/v1/estimates/vehicle',
+      'POST',
+      pathParams,
+      queryParams,
+      headerParams,
+      formParams,
+      postBody,
+      authNames,
+      contentTypes,
+      accepts,
+      returnType
+    );
+  }
+
+  createVehicleEstimate(createVehicleEstimateRequest) {
+    return this.createVehicleEstimateWithHttpInfo(createVehicleEstimateRequest);
   }
 
   retrieveEstimateWithHttpInfo(id) {

--- a/src/model/CreateFlightEstimateRequest.js
+++ b/src/model/CreateFlightEstimateRequest.js
@@ -1,0 +1,54 @@
+/**
+ * Patch API V1
+ * The core API used to integrate with Patch's service
+ *
+ * Contact: developers@usepatch.com
+ */
+
+import ApiClient from '../ApiClient';
+
+class CreateFlightEstimateRequest {
+  constructor(distanceM) {
+    CreateFlightEstimateRequest.initialize(this, distanceM);
+  }
+
+  static initialize(obj, distanceM) {
+    obj['distance_m'] = distanceM;
+  }
+
+  static constructFromObject(data, obj) {
+    if (data) {
+      obj = obj || new CreateFlightEstimateRequest();
+
+      if (data.hasOwnProperty('distance_m')) {
+        obj['distance_m'] = ApiClient.convertToType(
+          data['distance_m'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('project_id')) {
+        obj['project_id'] = ApiClient.convertToType(
+          data['project_id'],
+          'String'
+        );
+      }
+
+      if (data.hasOwnProperty('create_order')) {
+        obj['create_order'] = ApiClient.convertToType(
+          data['create_order'],
+          'Boolean'
+        );
+      }
+    }
+    return obj;
+  }
+}
+
+CreateFlightEstimateRequest.prototype['distance_m'] = undefined;
+
+CreateFlightEstimateRequest.prototype['project_id'] = undefined;
+
+CreateFlightEstimateRequest.prototype['create_order'] = undefined;
+
+export default CreateFlightEstimateRequest;

--- a/src/model/CreateMassEstimateRequest.js
+++ b/src/model/CreateMassEstimateRequest.js
@@ -24,6 +24,13 @@ class CreateMassEstimateRequest {
         obj['mass_g'] = ApiClient.convertToType(data['mass_g'], 'Number');
       }
 
+      if (data.hasOwnProperty('create_order')) {
+        obj['create_order'] = ApiClient.convertToType(
+          data['create_order'],
+          'Boolean'
+        );
+      }
+
       if (data.hasOwnProperty('project_id')) {
         obj['project_id'] = ApiClient.convertToType(
           data['project_id'],
@@ -36,6 +43,8 @@ class CreateMassEstimateRequest {
 }
 
 CreateMassEstimateRequest.prototype['mass_g'] = undefined;
+
+CreateMassEstimateRequest.prototype['create_order'] = undefined;
 
 CreateMassEstimateRequest.prototype['project_id'] = undefined;
 

--- a/src/model/CreateShippingEstimateRequest.js
+++ b/src/model/CreateShippingEstimateRequest.js
@@ -1,0 +1,79 @@
+/**
+ * Patch API V1
+ * The core API used to integrate with Patch's service
+ *
+ * Contact: developers@usepatch.com
+ */
+
+import ApiClient from '../ApiClient';
+
+class CreateShippingEstimateRequest {
+  constructor(distanceM, packageMassG, transportationMethod) {
+    CreateShippingEstimateRequest.initialize(
+      this,
+      distanceM,
+      packageMassG,
+      transportationMethod
+    );
+  }
+
+  static initialize(obj, distanceM, packageMassG, transportationMethod) {
+    obj['distance_m'] = distanceM;
+    obj['package_mass_g'] = packageMassG;
+    obj['transportation_method'] = transportationMethod;
+  }
+
+  static constructFromObject(data, obj) {
+    if (data) {
+      obj = obj || new CreateShippingEstimateRequest();
+
+      if (data.hasOwnProperty('distance_m')) {
+        obj['distance_m'] = ApiClient.convertToType(
+          data['distance_m'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('package_mass_g')) {
+        obj['package_mass_g'] = ApiClient.convertToType(
+          data['package_mass_g'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('transportation_method')) {
+        obj['transportation_method'] = ApiClient.convertToType(
+          data['transportation_method'],
+          'String'
+        );
+      }
+
+      if (data.hasOwnProperty('project_id')) {
+        obj['project_id'] = ApiClient.convertToType(
+          data['project_id'],
+          'String'
+        );
+      }
+
+      if (data.hasOwnProperty('create_order')) {
+        obj['create_order'] = ApiClient.convertToType(
+          data['create_order'],
+          'Boolean'
+        );
+      }
+    }
+    return obj;
+  }
+}
+
+CreateShippingEstimateRequest.prototype['distance_m'] = undefined;
+
+CreateShippingEstimateRequest.prototype['package_mass_g'] = undefined;
+
+CreateShippingEstimateRequest.prototype['transportation_method'] = undefined;
+
+CreateShippingEstimateRequest.prototype['project_id'] = undefined;
+
+CreateShippingEstimateRequest.prototype['create_order'] = undefined;
+
+export default CreateShippingEstimateRequest;

--- a/src/model/CreateVehicleEstimateRequest.js
+++ b/src/model/CreateVehicleEstimateRequest.js
@@ -1,0 +1,75 @@
+/**
+ * Patch API V1
+ * The core API used to integrate with Patch's service
+ *
+ * Contact: developers@usepatch.com
+ */
+
+import ApiClient from '../ApiClient';
+
+class CreateVehicleEstimateRequest {
+  constructor(distanceM, make, model, year) {
+    CreateVehicleEstimateRequest.initialize(this, distanceM, make, model, year);
+  }
+
+  static initialize(obj, distanceM, make, model, year) {
+    obj['distance_m'] = distanceM;
+    obj['make'] = make;
+    obj['model'] = model;
+    obj['year'] = year;
+  }
+
+  static constructFromObject(data, obj) {
+    if (data) {
+      obj = obj || new CreateVehicleEstimateRequest();
+
+      if (data.hasOwnProperty('distance_m')) {
+        obj['distance_m'] = ApiClient.convertToType(
+          data['distance_m'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('make')) {
+        obj['make'] = ApiClient.convertToType(data['make'], 'String');
+      }
+
+      if (data.hasOwnProperty('model')) {
+        obj['model'] = ApiClient.convertToType(data['model'], 'String');
+      }
+
+      if (data.hasOwnProperty('year')) {
+        obj['year'] = ApiClient.convertToType(data['year'], 'Number');
+      }
+
+      if (data.hasOwnProperty('project_id')) {
+        obj['project_id'] = ApiClient.convertToType(
+          data['project_id'],
+          'String'
+        );
+      }
+
+      if (data.hasOwnProperty('create_order')) {
+        obj['create_order'] = ApiClient.convertToType(
+          data['create_order'],
+          'Boolean'
+        );
+      }
+    }
+    return obj;
+  }
+}
+
+CreateVehicleEstimateRequest.prototype['distance_m'] = undefined;
+
+CreateVehicleEstimateRequest.prototype['make'] = undefined;
+
+CreateVehicleEstimateRequest.prototype['model'] = undefined;
+
+CreateVehicleEstimateRequest.prototype['year'] = undefined;
+
+CreateVehicleEstimateRequest.prototype['project_id'] = undefined;
+
+CreateVehicleEstimateRequest.prototype['create_order'] = undefined;
+
+export default CreateVehicleEstimateRequest;

--- a/src/model/Estimate.js
+++ b/src/model/Estimate.js
@@ -38,8 +38,12 @@ class Estimate {
         obj['type'] = ApiClient.convertToType(data['type'], 'String');
       }
 
+      if (data.hasOwnProperty('mass_g')) {
+        obj['mass_g'] = ApiClient.convertToType(data['mass_g'], 'Number');
+      }
+
       if (data.hasOwnProperty('order')) {
-        obj['order'] = Order.constructFromObject(data['order']);
+        obj['order'] = ApiClient.convertToType(data['order'], Order);
       }
     }
     return obj;
@@ -51,6 +55,8 @@ Estimate.prototype['id'] = undefined;
 Estimate.prototype['production'] = undefined;
 
 Estimate.prototype['type'] = undefined;
+
+Estimate.prototype['mass_g'] = undefined;
 
 Estimate.prototype['order'] = undefined;
 

--- a/src/model/Photo.js
+++ b/src/model/Photo.js
@@ -8,12 +8,13 @@
 import ApiClient from '../ApiClient';
 
 class Photo {
-  constructor(url) {
-    Photo.initialize(this, url);
+  constructor(url, id) {
+    Photo.initialize(this, url, id);
   }
 
-  static initialize(obj, url) {
+  static initialize(obj, url, id) {
     obj['url'] = url;
+    obj['id'] = id;
   }
 
   static constructFromObject(data, obj) {
@@ -23,11 +24,17 @@ class Photo {
       if (data.hasOwnProperty('url')) {
         obj['url'] = ApiClient.convertToType(data['url'], 'String');
       }
+
+      if (data.hasOwnProperty('id')) {
+        obj['id'] = ApiClient.convertToType(data['id'], 'String');
+      }
     }
     return obj;
   }
 }
 
 Photo.prototype['url'] = undefined;
+
+Photo.prototype['id'] = undefined;
 
 export default Photo;

--- a/src/model/Preference.js
+++ b/src/model/Preference.js
@@ -35,7 +35,7 @@ class Preference {
       }
 
       if (data.hasOwnProperty('project')) {
-        obj['project'] = Project.constructFromObject(data['project']);
+        obj['project'] = ApiClient.convertToType(data['project'], Project);
       }
     }
     return obj;

--- a/test/integration/estimates.spec.js
+++ b/test/integration/estimates.spec.js
@@ -19,4 +19,14 @@ describe('Estimates Integration', function () {
     });
     expect(retrieveEstimatesResponse.data.length).to.be.above(0);
   });
+
+  it('supports creating flight estimates', async function () {
+    const createEstimateResponse = await patch.estimates.createFlightEstimate({
+      distance_m: 1000
+    });
+    const estimate = createEstimateResponse.data;
+
+    expect(estimate.mass_g).to.be.above(0);
+    expect(estimate.production).to.be.eq(false);
+  });
 });

--- a/test/integration/estimates.spec.js
+++ b/test/integration/estimates.spec.js
@@ -13,6 +13,7 @@ describe('Estimates Integration', function () {
       estimateId
     );
     expect(retrieveEstimateResponse.data.id).to.equal(estimateId);
+    expect(retrieveEstimateResponse.data.order.state).to.equal('draft');
 
     const retrieveEstimatesResponse = await patch.estimates.retrieveEstimates({
       page: 1
@@ -20,13 +21,48 @@ describe('Estimates Integration', function () {
     expect(retrieveEstimatesResponse.data.length).to.be.above(0);
   });
 
-  it('supports creating flight estimates', async function () {
+  it('supports creating flight estimates with an order', async function () {
     const createEstimateResponse = await patch.estimates.createFlightEstimate({
-      distance_m: 1000
+      distance_m: 1000,
+      create_order: true
     });
     const estimate = createEstimateResponse.data;
 
+    expect(estimate.type).to.be.eq('flight');
     expect(estimate.mass_g).to.be.above(0);
     expect(estimate.production).to.be.eq(false);
+    expect(estimate.order.state).to.be.eq('draft');
+  });
+
+  it('supports creating shipping estimates without an order', async function () {
+    const createEstimateResponse = await patch.estimates.createShippingEstimate({
+      distance_m: 1000000,
+      transportation_method: 'rail',
+      package_mass_g: 50000,
+      create_order: false
+    });
+    const estimate = createEstimateResponse.data;
+
+    expect(estimate.type).to.be.eq('shipping');
+    expect(estimate.mass_g).to.be.above(0);
+    expect(estimate.production).to.be.eq(false);
+    expect(estimate.order).to.be.eq(null);
+  });
+
+
+  it('supports creating vehicle estimates without an order', async function () {
+    const createEstimateResponse = await patch.estimates.createVehicleEstimate({
+      distance_m: 1000000,
+      make: 'Toyota',
+      model: 'Corolla',
+      year: 2005,
+      create_order: false
+    });
+    const estimate = createEstimateResponse.data;
+
+    expect(estimate.type).to.be.eq('vehicle');
+    expect(estimate.mass_g).to.be.above(0);
+    expect(estimate.production).to.be.eq(false);
+    expect(estimate.order).to.be.eq(null);
   });
 });

--- a/test/integration/estimates.spec.js
+++ b/test/integration/estimates.spec.js
@@ -35,12 +35,14 @@ describe('Estimates Integration', function () {
   });
 
   it('supports creating shipping estimates without an order', async function () {
-    const createEstimateResponse = await patch.estimates.createShippingEstimate({
-      distance_m: 1000000,
-      transportation_method: 'rail',
-      package_mass_g: 50000,
-      create_order: false
-    });
+    const createEstimateResponse = await patch.estimates.createShippingEstimate(
+      {
+        distance_m: 1000000,
+        transportation_method: 'rail',
+        package_mass_g: 50000,
+        create_order: false
+      }
+    );
     const estimate = createEstimateResponse.data;
 
     expect(estimate.type).to.be.eq('shipping');
@@ -48,7 +50,6 @@ describe('Estimates Integration', function () {
     expect(estimate.production).to.be.eq(false);
     expect(estimate.order).to.be.eq(null);
   });
-
 
   it('supports creating vehicle estimates without an order', async function () {
     const createEstimateResponse = await patch.estimates.createVehicleEstimate({

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -39,8 +39,7 @@ describe('Orders Integration', function () {
     expect(placeOrderResponse.data.state).to.equal('placed');
     expect(placeOrderResponse.data.production).to.equal(false);
     expect(placeOrderResponse.data.mass_g).to.equal(100);
-    expect(placeOrderResponse.data.price_cents_usd).to.equal('1.0');
-    expect(placeOrderResponse.data.patch_fee_cents_usd).to.equal('0.0');
+    expect(placeOrderResponse.data.allocation_state).to.equal('pending');
   });
 
   it('supports cancelling orders in a `draft` state', async function () {

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -37,6 +37,8 @@ describe('Orders Integration', function () {
 
     const placeOrderResponse = await patch.orders.placeOrder(orderId);
     expect(placeOrderResponse.data.state).to.equal('placed');
+    expect(placeOrderResponse.data.production).to.equal(false);
+    expect(placeOrderResponse.data.mass_g).to.equal(100);
     expect(placeOrderResponse.data.price_cents_usd).to.equal('1.0');
     expect(placeOrderResponse.data.patch_fee_cents_usd).to.equal('0.0');
   });

--- a/test/integration/preferences.test.js
+++ b/test/integration/preferences.test.js
@@ -2,15 +2,16 @@ import { expect } from 'chai';
 import Patch from '../../dist/index';
 const patch = Patch(process.env.SANDBOX_API_KEY);
 
-describe('Preferences Integration', function (done) {
+describe('Preferences Integration', async function () {
   it('supports create, delete, retrieve and list', async function () {
     const projectResponse = await patch.projects.retrieveProjects();
     expect(projectResponse.data.length).to.be.above(0);
 
     const projectId = projectResponse.data[0].id;
+    let createPreferenceResponse;
 
     try {
-      await patch.preferences.createPreference({
+      createPreferenceResponse = await patch.preferences.createPreference({
         project_id: projectId
       });
     } catch ({ error }) {
@@ -21,15 +22,13 @@ describe('Preferences Integration', function (done) {
           (await patch.preferences.retrievePreferences()).data[0].id
         );
 
-        // Create it again
-        await patch.preferences.createPreference({
+        createPreferenceResponse = await patch.preferences.createPreference({
           project_id: projectId
         });
       }
     }
 
-    const preferenceId = (await patch.preferences.retrievePreferences()).data[0]
-      .id;
+    const preferenceId = createPreferenceResponse.data.id;
     const retrievePreferenceResponse = await patch.preferences.retrievePreference(
       preferenceId
     );
@@ -44,7 +43,5 @@ describe('Preferences Integration', function (done) {
       preferenceId
     );
     expect(deletePreferenceResponse.data.id).to.equal(preferenceId);
-
-    done;
   });
 });

--- a/test/integration/preferences.test.js
+++ b/test/integration/preferences.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import Patch from '../../dist/index';
 const patch = Patch(process.env.SANDBOX_API_KEY);
 
-describe('Preferences Integration', function () {
+describe('Preferences Integration', function (done) {
   it('supports create, delete, retrieve and list', async function () {
     const projectResponse = await patch.projects.retrieveProjects();
     expect(projectResponse.data.length).to.be.above(0);
@@ -21,13 +21,15 @@ describe('Preferences Integration', function () {
           (await patch.preferences.retrievePreferences()).data[0].id
         );
 
+        // Create it again
         await patch.preferences.createPreference({
           project_id: projectId
         });
       }
     }
 
-    const preferenceId = (await patch.preferences.retrievePreferences()).data[0].id
+    const preferenceId = (await patch.preferences.retrievePreferences()).data[0]
+      .id;
     const retrievePreferenceResponse = await patch.preferences.retrievePreference(
       preferenceId
     );
@@ -42,5 +44,7 @@ describe('Preferences Integration', function () {
       preferenceId
     );
     expect(deletePreferenceResponse.data.id).to.equal(preferenceId);
+
+    done;
   });
 });

--- a/test/integration/preferences.test.js
+++ b/test/integration/preferences.test.js
@@ -3,45 +3,45 @@ import Patch from '../../dist/index';
 const patch = Patch(process.env.SANDBOX_API_KEY);
 
 describe('Preferences Integration', async function () {
-  it('supports create, delete, retrieve and list', async function () {
-    const projectResponse = await patch.projects.retrieveProjects();
-    expect(projectResponse.data.length).to.be.above(0);
+  it('supports creating, deleting, and listing preferences', async function () {
+    const preferencesList = await patch.preferences.retrievePreferences();
 
-    const projectId = projectResponse.data[0].id;
-    let createPreferenceResponse;
+    // If there is an existing preference, delete it and create a new one with the same
+    // project id. If there is not any existing preferences, create and delete one with
+    // any project id.
+    if (preferencesList.data.length > 0) {
+      const preference = preferencesList.data[0];
+      const projectId = preference.project.id;
 
-    try {
-      createPreferenceResponse = await patch.preferences.createPreference({
+      await patch.preferences.deletePreference(preference.id);
+      const createdPreference = await patch.preferences.createPreference({
         project_id: projectId
       });
-    } catch ({ error }) {
-      // If there's a preference that exists already
-      if (error.code === 422) {
-        // Delete the preference
-        await patch.preferences.deletePreference(
-          (await patch.preferences.retrievePreferences()).data[0].id
-        );
 
-        createPreferenceResponse = await patch.preferences.createPreference({
-          project_id: projectId
-        });
-      }
+      expect(createdPreference.data.project.id).to.eq(projectId);
+
+      const preferencesList2 = await patch.preferences.retrievePreferences();
+      expect(preferencesList2.data.length).to.be.above(0);
+    } else {
+      const projectResponse = await patch.projects.retrieveProjects();
+      expect(projectResponse.data.length).to.be.above(0);
+      const projectId = projectResponse.data[0].id;
+
+      const createdPreference = await patch.preferences.createPreference({
+        project_id: projectId
+      });
+      console.log(createdPreference);
+
+      expect(createdPreference.data.projectId).to.eq(projectId);
+
+      const preferencesList2 = await patch.preferences.retrievePreferences();
+      const preferencesCount = preferencesList2.data.length;
+      expect(preferencesList2.data.length).to.be.above(0);
+
+      await patch.preferences.deletePreference(preference.id);
+
+      const preferencesList3 = await patch.preferences.retrievePreferences();
+      expect(preferencesList3.data.length).to.eq(preferencesCount - 1);
     }
-
-    const preferenceId = createPreferenceResponse.data.id;
-    const retrievePreferenceResponse = await patch.preferences.retrievePreference(
-      preferenceId
-    );
-    expect(retrievePreferenceResponse.data.id).to.equal(preferenceId);
-
-    const retrievePreferencesResponse = await patch.preferences.retrievePreferences(
-      { page: 1 }
-    );
-    expect(retrievePreferencesResponse.data[0].id).to.equal(preferenceId);
-
-    const deletePreferenceResponse = await patch.preferences.deletePreference(
-      preferenceId
-    );
-    expect(deletePreferenceResponse.data.id).to.equal(preferenceId);
   });
 });

--- a/test/integration/preferences.test.js
+++ b/test/integration/preferences.test.js
@@ -8,10 +8,9 @@ describe('Preferences Integration', function () {
     expect(projectResponse.data.length).to.be.above(0);
 
     const projectId = projectResponse.data[0].id;
-    let createPreferenceResponse;
 
     try {
-      createPreferenceResponse = await patch.preferences.createPreference({
+      await patch.preferences.createPreference({
         project_id: projectId
       });
     } catch ({ error }) {
@@ -22,13 +21,13 @@ describe('Preferences Integration', function () {
           (await patch.preferences.retrievePreferences()).data[0].id
         );
 
-        createPreferenceResponse = await patch.preferences.createPreference({
+        await patch.preferences.createPreference({
           project_id: projectId
         });
       }
     }
 
-    const preferenceId = createPreferenceResponse.data.id;
+    const preferenceId = (await patch.preferences.retrievePreferences()).data[0].id
     const retrievePreferenceResponse = await patch.preferences.retrievePreference(
       preferenceId
     );


### PR DESCRIPTION
### What

- Adds support for Flight/Vehicle/Shipping estimates
- Update to version 1.3.5 

### Why

- To extend the Node package to support different kinds of estimates to be created

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] ~~For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?~~
