### PR TITLE
Add created_at on orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2021-09-08
+
+### Added
+
+- Adds a `created_at` attribute in all order responses
+
 ## [1.11.1] - 2021-09-07
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -16,7 +16,7 @@ class ApiClient {
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/1.11.1'
+      'User-Agent': 'patch-node/1.12.0'
     };
 
     /**

--- a/src/model/CreateBitcoinEstimateRequest.js
+++ b/src/model/CreateBitcoinEstimateRequest.js
@@ -19,7 +19,7 @@ class CreateBitcoinEstimateRequest {
       obj = obj || new CreateBitcoinEstimateRequest();
 
       if (data.hasOwnProperty('timestamp')) {
-        obj['timestamp'] = ApiClient.convertToType(data['timestamp'], 'String');
+        obj['timestamp'] = ApiClient.convertToType(data['timestamp'], 'Date');
       }
 
       if (data.hasOwnProperty('transaction_value_btc_sats')) {

--- a/src/model/Order.js
+++ b/src/model/Order.js
@@ -65,6 +65,10 @@ class Order {
         obj['id'] = ApiClient.convertToType(data['id'], 'String');
       }
 
+      if (data.hasOwnProperty('created_at')) {
+        obj['created_at'] = ApiClient.convertToType(data['created_at'], 'Date');
+      }
+
       if (data.hasOwnProperty('mass_g')) {
         obj['mass_g'] = ApiClient.convertToType(data['mass_g'], 'Number');
       }
@@ -123,6 +127,8 @@ class Order {
 }
 
 Order.prototype['id'] = undefined;
+
+Order.prototype['created_at'] = undefined;
 
 Order.prototype['mass_g'] = undefined;
 

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -34,7 +34,7 @@ describe('Orders Integration', function () {
     expect(estimateResponse.data.order.state).to.equal('draft');
 
     const placeOrderResponse = await patch.orders.placeOrder(orderId);
-    expect(placeOrderResponse.data.state).to.equal('placed');
+    expect(placeOrderResponse.data.created_at).to.be.an.instanceOf(Date);
     expect(placeOrderResponse.data.production).to.equal(false);
     expect(placeOrderResponse.data.mass_g).to.equal(100);
   });


### PR DESCRIPTION
### What

- Surface the `created_at` field on all order responses

### Why

- For ease of use when retrieving orders

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the package locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
