### PR TITLE
Bump OpenAPI generator version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 2022-01-07
+
+### Changed
+
+- No feature changes. Updates the openapi-generator version.
+
 ## [1.16.0] - 2021-12-07
 
 ### Removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -9,14 +9,14 @@ import superagent from 'superagent';
 import querystring from 'query-string';
 
 class ApiClient {
-  constructor() {
-    this.basePath = 'https://api.patch.io'.replace(/\/+$/, '');
+  constructor(basePath = 'https://api.patch.io') {
+    this.basePath = basePath.replace(/\/+$/, '');
     this.authentications = {
       bearer_auth: { type: 'bearer' }
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/1.16.0'
+      'User-Agent': 'patch-node/1.16.1'
     };
 
     /**


### PR DESCRIPTION
### What

- Update to the latest OpenAPI generator version
- No breaking changes

### Why

- Bring updates and bug fixes

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the package locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
