### PR TITLE
remove .default from es6 api key config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ After installing the package, you'll have to configure it with your API key whic
 ```javascript
 // ES6+
 import Patch from '@patch-technology/patch';
-const patch = Patch.default('key_test_1234');
+const patch = Patch('key_test_1234');
 
 // ES5
 var patch = require('@patch-technology/patch').default('key_test_1234');


### PR DESCRIPTION
### What

Update README for ES6+ API key configuration

### Why

The example is invalid, `Patch.default(` should be `Patch(`. 

### SDK Release Checklist

Have not done any of the below since it is just a fix for the README.

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the package locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
