### PR TITLE
Update to make the order allocations array optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2022-01-11
+
+### Changed
+
+- Set the order allocatations array as optional.
+
 ## [1.16.1] - 2022-01-07
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -9,14 +9,14 @@ import superagent from 'superagent';
 import querystring from 'query-string';
 
 class ApiClient {
-  constructor(basePath = 'https://api.patch.io') {
-    this.basePath = basePath.replace(/\/+$/, '');
+  constructor() {
+    this.basePath = 'https://api.patch.io'.replace(/\/+$/, '');
     this.authentications = {
       bearer_auth: { type: 'bearer' }
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/1.16.1'
+      'User-Agent': 'patch-node/1.17.0'
     };
 
     /**

--- a/src/model/Order.js
+++ b/src/model/Order.js
@@ -17,7 +17,6 @@ class Order {
     allocationState,
     priceCentsUsd,
     patchFeeCentsUsd,
-    allocations,
     metadata
   ) {
     Order.initialize(
@@ -29,7 +28,6 @@ class Order {
       allocationState,
       priceCentsUsd,
       patchFeeCentsUsd,
-      allocations,
       metadata
     );
   }
@@ -43,7 +41,6 @@ class Order {
     allocationState,
     priceCentsUsd,
     patchFeeCentsUsd,
-    allocations,
     metadata
   ) {
     obj['id'] = id;
@@ -53,7 +50,6 @@ class Order {
     obj['allocation_state'] = allocationState;
     obj['price_cents_usd'] = priceCentsUsd;
     obj['patch_fee_cents_usd'] = patchFeeCentsUsd;
-    obj['allocations'] = allocations;
     obj['metadata'] = metadata;
   }
 


### PR DESCRIPTION
### What

* Changing the order allocations array to be optional

### Why

* Allocations will not always be available for an order

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the package locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
