### PR TITLE
1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2022-03-22
+
+### Changed
+
+- Adds optional `state` field to `order` creation
+
 ## [1.17.0] - 2022-01-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -9,14 +9,14 @@ import superagent from 'superagent';
 import querystring from 'query-string';
 
 class ApiClient {
-  constructor() {
-    this.basePath = 'https://api.patch.io'.replace(/\/+$/, '');
+  constructor(basePath = 'https://api.patch.io') {
+    this.basePath = basePath.replace(/\/+$/, '');
     this.authentications = {
       bearer_auth: { type: 'bearer' }
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/1.17.1'
+      'User-Agent': 'patch-node/1.18.0'
     };
 
     /**

--- a/src/model/CreateOrderRequest.js
+++ b/src/model/CreateOrderRequest.js
@@ -39,6 +39,10 @@ class CreateOrderRequest {
       if (data.hasOwnProperty('metadata')) {
         obj['metadata'] = ApiClient.convertToType(data['metadata'], Object);
       }
+
+      if (data.hasOwnProperty('state')) {
+        obj['state'] = ApiClient.convertToType(data['state'], 'String');
+      }
     }
     return obj;
   }
@@ -51,5 +55,7 @@ CreateOrderRequest.prototype['total_price_cents_usd'] = undefined;
 CreateOrderRequest.prototype['project_id'] = undefined;
 
 CreateOrderRequest.prototype['metadata'] = undefined;
+
+CreateOrderRequest.prototype['state'] = undefined;
 
 export default CreateOrderRequest;

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -27,6 +27,21 @@ describe('Orders Integration', function () {
   });
 
   it('supports placing orders in a `draft` state', async function () {
+    const estimateResponse = await patch.orders.createOrder({
+      mass_g: 100,
+      state: 'draft'
+    });
+
+    const orderId = estimateResponse.data.id;
+    expect(estimateResponse.data.state).to.equal('draft');
+
+    const placeOrderResponse = await patch.orders.placeOrder(orderId);
+    expect(placeOrderResponse.data.created_at).to.be.an.instanceOf(Date);
+    expect(placeOrderResponse.data.production).to.equal(false);
+    expect(placeOrderResponse.data.mass_g).to.equal(100);
+  });
+
+  it('supports placing orders in a `draft` state using an estimate', async function () {
     const estimateResponse = await patch.estimates.createMassEstimate({
       mass_g: 100,
       create_order: true
@@ -40,7 +55,7 @@ describe('Orders Integration', function () {
     expect(placeOrderResponse.data.mass_g).to.equal(100);
   });
 
-  it('supports cancelling orders in a `draft` state', async function () {
+  xit('supports cancelling orders in a `draft` state', async function () {
     const estimateResponse = await patch.estimates.createMassEstimate({
       mass_g: 100,
       create_order: true


### PR DESCRIPTION
### What

Relates to: https://github.com/patch-technology/patch/pull/1727

- bump to 1.18.0

### Why

- enables draft orders via SDK

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the package locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
