### PR TITLE
1.20.0 - create order by vintage year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2022-04-18
+
+### Added
+
+- Adds optional `vintage_year` field to `order` creation
+
 ## [1.19.0] - 2022-04-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -16,7 +16,7 @@ class ApiClient {
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/1.19.0'
+      'User-Agent': 'patch-node/1.20.0'
     };
 
     /**

--- a/src/model/CreateOrderRequest.js
+++ b/src/model/CreateOrderRequest.js
@@ -43,6 +43,13 @@ class CreateOrderRequest {
       if (data.hasOwnProperty('state')) {
         obj['state'] = ApiClient.convertToType(data['state'], 'String');
       }
+
+      if (data.hasOwnProperty('vintage_year')) {
+        obj['vintage_year'] = ApiClient.convertToType(
+          data['vintage_year'],
+          'Number'
+        );
+      }
     }
     return obj;
   }
@@ -57,5 +64,7 @@ CreateOrderRequest.prototype['project_id'] = undefined;
 CreateOrderRequest.prototype['metadata'] = undefined;
 
 CreateOrderRequest.prototype['state'] = undefined;
+
+CreateOrderRequest.prototype['vintage_year'] = undefined;
 
 export default CreateOrderRequest;

--- a/test/integration/orders.test.js
+++ b/test/integration/orders.test.js
@@ -83,4 +83,13 @@ describe('Orders Integration', function () {
       expect(order.metadata).to.have.all.keys('external_id');
     });
   });
+
+  it('supports create orders with a vintage year', async function () {
+    const createOrderResponse = await patch.orders.createOrder({
+      mass_g: 100,
+      vintage_year: 2022
+    });
+
+    expect(createOrderResponse.success).to.equal(true);
+  });
 });


### PR DESCRIPTION
### What

- enabling vintage year to create projects: https://github.com/patch-technology/patch/pull/1864

### Why

- so that users can order a specific vintage year

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the package locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
