### PR TITLE
Add /estimates/ecommerce API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2022-08-10
+
+### Added
+
+- Adds `patch.estimates.createEcommerceEstimate` method
+
 ## [1.24.0] - 2022-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ patch.estimates.createMassEstimate({ mass_g });
 const distance_m = 9000000; // Pass in the distance traveled in meters
 patch.estimates.createFlightEstimate({ distance_m });
 
-// Create a shipping estimate
+// Create an ecommerce estimate
 const distance_m = 9000000;
 // Pass in the shipping distance in meters, the transportation method, and the package mass
-patch.estimates.createShippingEstimate({
+patch.estimates.createEcommerceEstimate({
   distance_m,
-  transportation_method: 'air',
-  package_mass_g: 1000
+  package_mass_g: 1000,
+  transportation_method: 'air'
 });
 
 // Create a bitcoin estimate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -16,7 +16,7 @@ class ApiClient {
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/1.24.1'
+      'User-Agent': 'patch-node/1.24.2'
     };
 
     /**

--- a/src/api/EstimatesApi.js
+++ b/src/api/EstimatesApi.js
@@ -8,6 +8,7 @@
 import ApiClient from '../ApiClient';
 import CreateAirShippingEstimateRequest from '../model/CreateAirShippingEstimateRequest';
 import CreateBitcoinEstimateRequest from '../model/CreateBitcoinEstimateRequest';
+import CreateEcommerceEstimateRequest from '../model/CreateEcommerceEstimateRequest';
 import CreateEthereumEstimateRequest from '../model/CreateEthereumEstimateRequest';
 import CreateFlightEstimateRequest from '../model/CreateFlightEstimateRequest';
 import CreateHotelEstimateRequest from '../model/CreateHotelEstimateRequest';
@@ -120,6 +121,55 @@ export default class EstimatesApi {
 
   createBitcoinEstimate(createBitcoinEstimateRequest) {
     return this.createBitcoinEstimateWithHttpInfo(createBitcoinEstimateRequest);
+  }
+
+  createEcommerceEstimateWithHttpInfo(createEcommerceEstimateRequest) {
+    const _createEcommerceEstimateRequest =
+      CreateEcommerceEstimateRequest.constructFromObject(
+        createEcommerceEstimateRequest,
+        new CreateEcommerceEstimateRequest()
+      );
+
+    // verify the required parameter 'createEcommerceEstimateRequest' is set
+    if (
+      _createEcommerceEstimateRequest === undefined ||
+      _createEcommerceEstimateRequest === null
+    ) {
+      throw new Error(
+        "Missing the required parameter 'createEcommerceEstimateRequest' when calling createEcommerceEstimate"
+      );
+    }
+
+    let postBody = _createEcommerceEstimateRequest;
+    let pathParams = {};
+    let queryParams = {};
+    let headerParams = {};
+    let formParams = {};
+
+    let authNames = ['bearer_auth'];
+    let contentTypes = ['application/json'];
+    let accepts = ['application/json'];
+    let returnType = EstimateResponse;
+
+    return this.apiClient.callApi(
+      '/v1/estimates/ecommerce',
+      'POST',
+      pathParams,
+      queryParams,
+      headerParams,
+      formParams,
+      postBody,
+      authNames,
+      contentTypes,
+      accepts,
+      returnType
+    );
+  }
+
+  createEcommerceEstimate(createEcommerceEstimateRequest) {
+    return this.createEcommerceEstimateWithHttpInfo(
+      createEcommerceEstimateRequest
+    );
   }
 
   createEthereumEstimateWithHttpInfo(createEthereumEstimateRequest) {

--- a/src/model/CreateAirShippingEstimateRequest.js
+++ b/src/model/CreateAirShippingEstimateRequest.js
@@ -88,7 +88,7 @@ CreateAirShippingEstimateRequest.prototype['aircraft_type'] = 'unknown';
 
 CreateAirShippingEstimateRequest.prototype['freight_mass_g'] = undefined;
 
-CreateAirShippingEstimateRequest.prototype['emissions_scope'] = 'wtw';
+CreateAirShippingEstimateRequest.prototype['emissions_scope'] = 'ttw';
 
 CreateAirShippingEstimateRequest.prototype['project_id'] = undefined;
 

--- a/src/model/CreateEcommerceEstimateRequest.js
+++ b/src/model/CreateEcommerceEstimateRequest.js
@@ -1,0 +1,79 @@
+/**
+ * Patch API V1
+ * The core API used to integrate with Patch's service
+ *
+ * Contact: engineering@usepatch.com
+ */
+
+import ApiClient from '../ApiClient';
+
+class CreateEcommerceEstimateRequest {
+  constructor(distanceM, packageMassG, transportationMethod) {
+    CreateEcommerceEstimateRequest.initialize(
+      this,
+      distanceM,
+      packageMassG,
+      transportationMethod
+    );
+  }
+
+  static initialize(obj, distanceM, packageMassG, transportationMethod) {
+    obj['distance_m'] = distanceM;
+    obj['package_mass_g'] = packageMassG;
+    obj['transportation_method'] = transportationMethod;
+  }
+
+  static constructFromObject(data, obj) {
+    if (data) {
+      obj = obj || new CreateEcommerceEstimateRequest();
+
+      if (data.hasOwnProperty('distance_m')) {
+        obj['distance_m'] = ApiClient.convertToType(
+          data['distance_m'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('package_mass_g')) {
+        obj['package_mass_g'] = ApiClient.convertToType(
+          data['package_mass_g'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('transportation_method')) {
+        obj['transportation_method'] = ApiClient.convertToType(
+          data['transportation_method'],
+          'String'
+        );
+      }
+
+      if (data.hasOwnProperty('project_id')) {
+        obj['project_id'] = ApiClient.convertToType(
+          data['project_id'],
+          'String'
+        );
+      }
+
+      if (data.hasOwnProperty('create_order')) {
+        obj['create_order'] = ApiClient.convertToType(
+          data['create_order'],
+          'Boolean'
+        );
+      }
+    }
+    return obj;
+  }
+}
+
+CreateEcommerceEstimateRequest.prototype['distance_m'] = undefined;
+
+CreateEcommerceEstimateRequest.prototype['package_mass_g'] = undefined;
+
+CreateEcommerceEstimateRequest.prototype['transportation_method'] = undefined;
+
+CreateEcommerceEstimateRequest.prototype['project_id'] = undefined;
+
+CreateEcommerceEstimateRequest.prototype['create_order'] = false;
+
+export default CreateEcommerceEstimateRequest;

--- a/src/model/CreateRailShippingEstimateRequest.js
+++ b/src/model/CreateRailShippingEstimateRequest.js
@@ -114,7 +114,7 @@ CreateRailShippingEstimateRequest.prototype['fuel_type'] = 'default';
 
 CreateRailShippingEstimateRequest.prototype['freight_mass_g'] = undefined;
 
-CreateRailShippingEstimateRequest.prototype['emissions_scope'] = 'wtw';
+CreateRailShippingEstimateRequest.prototype['emissions_scope'] = 'ttw';
 
 CreateRailShippingEstimateRequest.prototype['project_id'] = undefined;
 

--- a/src/model/CreateRoadShippingEstimateRequest.js
+++ b/src/model/CreateRoadShippingEstimateRequest.js
@@ -142,7 +142,7 @@ CreateRoadShippingEstimateRequest.prototype['cargo_type'] = 'average_mixed';
 
 CreateRoadShippingEstimateRequest.prototype['container_size_code'] = undefined;
 
-CreateRoadShippingEstimateRequest.prototype['emissions_scope'] = 'wtw';
+CreateRoadShippingEstimateRequest.prototype['emissions_scope'] = 'ttw';
 
 CreateRoadShippingEstimateRequest.prototype['freight_mass_g'] = undefined;
 

--- a/src/model/CreateSeaShippingEstimateRequest.js
+++ b/src/model/CreateSeaShippingEstimateRequest.js
@@ -136,7 +136,7 @@ CreateSeaShippingEstimateRequest.prototype['origin_postal_code'] = undefined;
 
 CreateSeaShippingEstimateRequest.prototype['container_size_code'] = undefined;
 
-CreateSeaShippingEstimateRequest.prototype['emissions_scope'] = 'wtw';
+CreateSeaShippingEstimateRequest.prototype['emissions_scope'] = 'ttw';
 
 CreateSeaShippingEstimateRequest.prototype['freight_mass_g'] = undefined;
 

--- a/test/integration/estimates.test.js
+++ b/test/integration/estimates.test.js
@@ -52,6 +52,22 @@ describe('Estimates Integration', function () {
     expect(estimate.order).to.be.eq(null);
   });
 
+  it('supports creating ecommerce estimates', async function () {
+    const createEstimateResponse =
+      await patch.estimates.createEcommerceEstimate({
+        create_order: false,
+        distance_m: 100000,
+        package_mass_g: 50000,
+        transportation_method: 'rail'
+      });
+    const estimate = createEstimateResponse.data;
+
+    expect(estimate.type).to.be.eq('ecommerce');
+    expect(estimate.mass_g).to.be.above(0);
+    expect(estimate.production).to.be.eq(false);
+    expect(estimate.order).to.be.eq(null);
+  });
+
   it('supports creating vehicle estimates without an order', async function () {
     const createEstimateResponse = await patch.estimates.createVehicleEstimate({
       distance_m: 100000,


### PR DESCRIPTION
### What
- Adds `patch.estimates.createEcommerceEstimate` method

### Why
New endpoint for our ecommerce customers!

** CHANGEME: Why are these changes needed? **

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the package locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
