### PR TITLE
API version 2.1.0 See https://docs.patch.io/#/changelog for changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2023-03-30
+
+### Added
+
+- Adds optional `vintage_start_year` and `vintage_end_year` field to `order` creation
+- Adds optional `vintage_start_year` and `vintage_end_year` field to `order_line_item` create and update
+- Adds optional `vintage_start_year` and `vintage_end_year` field to `inventory` creation
+- Adds `vintage_start_year` and `vintage_end_year` field to `order` response
+- Adds `vintage_start_year` and `vintage_end_year` field to `order_line_item` response
+- Adds optional `carrier_scac` field to `patch.estimates.create_road_shipping_estimate`
+
 ## [1.24.2] - 2022-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - 2023-03-30
+## [2.1.0] - 2023-04-04
 
 ### Added
 
-- Adds optional `vintage_start_year` and `vintage_end_year` field to `order` creation
-- Adds optional `vintage_start_year` and `vintage_end_year` field to `order_line_item` create and update
-- Adds optional `vintage_start_year` and `vintage_end_year` field to `inventory` creation
-- Adds `vintage_start_year` and `vintage_end_year` field to `order` response
-- Adds `vintage_start_year` and `vintage_end_year` field to `order_line_item` response
-- Adds optional `carrier_scac` field to `patch.estimates.create_road_shipping_estimate`
+- Adds optional `vintage_start_year` and `vintage_end_year` fields to `order` creation
+- Adds optional `vintage_start_year` and `vintage_end_year` fields to `order_line_item` create and update
+- Adds optional `vintage_start_year` and `vintage_end_year` fields to `inventory` creation
+- Adds `vintage_start_year` and `vintage_end_year` fields to `order` response
+- Adds `vintage_start_year` and `vintage_end_year` fields to `order_line_item` response
+- Adds optional `carrier_scac` field to `patch.estimates.createRoadShippingEstimate`
+- Deprecates `createShippingEstimate` in favor of `createEcommerceEstimate`
 
 ## [1.24.2] - 2022-08-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",
@@ -2178,9 +2178,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001341",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
-      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
+      "version": "1.0.30001469",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
+      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
       "dev": true,
       "funding": [
         {
@@ -6597,9 +6597,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001341",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
-      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
+      "version": "1.0.30001469",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
+      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
       "dev": true
     },
     "chai": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.5.4",
     "mocha": "^9.1.0",
-    "prettier": "^2.0.5",
-    "sinon": "^7.2.0"
+    "sinon": "^7.2.0",
+    "prettier": "^2.0.5"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {
@@ -49,8 +49,8 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.5.4",
     "mocha": "^9.1.0",
-    "sinon": "^7.2.0",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "sinon": "^7.2.0"
   },
   "files": [
     "dist"

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -16,7 +16,7 @@ class ApiClient {
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/2.0.1',
+      'User-Agent': 'patch-node/2.1.0',
       'Patch-Version': 2
     };
 

--- a/src/model/CreateOrderLineItemRequest.js
+++ b/src/model/CreateOrderLineItemRequest.js
@@ -32,6 +32,20 @@ class CreateOrderLineItemRequest {
         );
       }
 
+      if (data.hasOwnProperty('vintage_start_year')) {
+        obj['vintage_start_year'] = ApiClient.convertToType(
+          data['vintage_start_year'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('vintage_end_year')) {
+        obj['vintage_end_year'] = ApiClient.convertToType(
+          data['vintage_end_year'],
+          'Number'
+        );
+      }
+
       if (data.hasOwnProperty('price')) {
         obj['price'] = ApiClient.convertToType(data['price'], 'Number');
       }
@@ -55,6 +69,10 @@ class CreateOrderLineItemRequest {
 CreateOrderLineItemRequest.prototype['project_id'] = undefined;
 
 CreateOrderLineItemRequest.prototype['vintage_year'] = undefined;
+
+CreateOrderLineItemRequest.prototype['vintage_start_year'] = undefined;
+
+CreateOrderLineItemRequest.prototype['vintage_end_year'] = undefined;
 
 CreateOrderLineItemRequest.prototype['price'] = undefined;
 

--- a/src/model/CreateOrderRequest.js
+++ b/src/model/CreateOrderRequest.js
@@ -41,6 +41,20 @@ class CreateOrderRequest {
         );
       }
 
+      if (data.hasOwnProperty('vintage_start_year')) {
+        obj['vintage_start_year'] = ApiClient.convertToType(
+          data['vintage_start_year'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('vintage_end_year')) {
+        obj['vintage_end_year'] = ApiClient.convertToType(
+          data['vintage_end_year'],
+          'Number'
+        );
+      }
+
       if (data.hasOwnProperty('total_price')) {
         obj['total_price'] = ApiClient.convertToType(
           data['total_price'],
@@ -75,6 +89,10 @@ CreateOrderRequest.prototype['metadata'] = undefined;
 CreateOrderRequest.prototype['state'] = undefined;
 
 CreateOrderRequest.prototype['vintage_year'] = undefined;
+
+CreateOrderRequest.prototype['vintage_start_year'] = undefined;
+
+CreateOrderRequest.prototype['vintage_end_year'] = undefined;
 
 CreateOrderRequest.prototype['total_price'] = undefined;
 

--- a/src/model/CreateRoadShippingEstimateRequest.js
+++ b/src/model/CreateRoadShippingEstimateRequest.js
@@ -106,6 +106,13 @@ class CreateRoadShippingEstimateRequest {
         );
       }
 
+      if (data.hasOwnProperty('carrier_scac')) {
+        obj['carrier_scac'] = ApiClient.convertToType(
+          data['carrier_scac'],
+          'String'
+        );
+      }
+
       if (data.hasOwnProperty('project_id')) {
         obj['project_id'] = ApiClient.convertToType(
           data['project_id'],
@@ -151,6 +158,8 @@ CreateRoadShippingEstimateRequest.prototype['fuel_type'] = 'diesel';
 CreateRoadShippingEstimateRequest.prototype['number_of_containers'] = undefined;
 
 CreateRoadShippingEstimateRequest.prototype['truck_weight_t'] = undefined;
+
+CreateRoadShippingEstimateRequest.prototype['carrier_scac'] = undefined;
 
 CreateRoadShippingEstimateRequest.prototype['project_id'] = undefined;
 

--- a/src/model/Inventory.js
+++ b/src/model/Inventory.js
@@ -8,10 +8,20 @@
 import ApiClient from '../ApiClient';
 
 class Inventory {
-  constructor(vintageYear, amountAvailable, price, currency, unit) {
+  constructor(
+    vintageYear,
+    vintageStartYear,
+    vintageEndYear,
+    amountAvailable,
+    price,
+    currency,
+    unit
+  ) {
     Inventory.initialize(
       this,
       vintageYear,
+      vintageStartYear,
+      vintageEndYear,
       amountAvailable,
       price,
       currency,
@@ -19,8 +29,19 @@ class Inventory {
     );
   }
 
-  static initialize(obj, vintageYear, amountAvailable, price, currency, unit) {
+  static initialize(
+    obj,
+    vintageYear,
+    vintageStartYear,
+    vintageEndYear,
+    amountAvailable,
+    price,
+    currency,
+    unit
+  ) {
     obj['vintage_year'] = vintageYear;
+    obj['vintage_start_year'] = vintageStartYear;
+    obj['vintage_end_year'] = vintageEndYear;
     obj['amount_available'] = amountAvailable;
     obj['price'] = price;
     obj['currency'] = currency;
@@ -34,6 +55,20 @@ class Inventory {
       if (data.hasOwnProperty('vintage_year')) {
         obj['vintage_year'] = ApiClient.convertToType(
           data['vintage_year'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('vintage_start_year')) {
+        obj['vintage_start_year'] = ApiClient.convertToType(
+          data['vintage_start_year'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('vintage_end_year')) {
+        obj['vintage_end_year'] = ApiClient.convertToType(
+          data['vintage_end_year'],
           'Number'
         );
       }
@@ -62,6 +97,10 @@ class Inventory {
 }
 
 Inventory.prototype['vintage_year'] = undefined;
+
+Inventory.prototype['vintage_start_year'] = undefined;
+
+Inventory.prototype['vintage_end_year'] = undefined;
 
 Inventory.prototype['amount_available'] = undefined;
 

--- a/src/model/OrderLineItem.js
+++ b/src/model/OrderLineItem.js
@@ -9,11 +9,22 @@ import ApiClient from '../ApiClient';
 import OrderLineItemProject from './OrderLineItemProject';
 
 class OrderLineItem {
-  constructor(project, vintageYear, amount, unit, price, currency) {
+  constructor(
+    project,
+    vintageYear,
+    vintageStartYear,
+    vintageEndYear,
+    amount,
+    unit,
+    price,
+    currency
+  ) {
     OrderLineItem.initialize(
       this,
       project,
       vintageYear,
+      vintageStartYear,
+      vintageEndYear,
       amount,
       unit,
       price,
@@ -21,9 +32,21 @@ class OrderLineItem {
     );
   }
 
-  static initialize(obj, project, vintageYear, amount, unit, price, currency) {
+  static initialize(
+    obj,
+    project,
+    vintageYear,
+    vintageStartYear,
+    vintageEndYear,
+    amount,
+    unit,
+    price,
+    currency
+  ) {
     obj['project'] = project;
     obj['vintage_year'] = vintageYear;
+    obj['vintage_start_year'] = vintageStartYear;
+    obj['vintage_end_year'] = vintageEndYear;
     obj['amount'] = amount;
     obj['unit'] = unit;
     obj['price'] = price;
@@ -48,6 +71,20 @@ class OrderLineItem {
       if (data.hasOwnProperty('vintage_year')) {
         obj['vintage_year'] = ApiClient.convertToType(
           data['vintage_year'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('vintage_start_year')) {
+        obj['vintage_start_year'] = ApiClient.convertToType(
+          data['vintage_start_year'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('vintage_end_year')) {
+        obj['vintage_end_year'] = ApiClient.convertToType(
+          data['vintage_end_year'],
           'Number'
         );
       }
@@ -77,6 +114,10 @@ OrderLineItem.prototype['id'] = undefined;
 OrderLineItem.prototype['project'] = undefined;
 
 OrderLineItem.prototype['vintage_year'] = undefined;
+
+OrderLineItem.prototype['vintage_start_year'] = undefined;
+
+OrderLineItem.prototype['vintage_end_year'] = undefined;
 
 OrderLineItem.prototype['amount'] = undefined;
 

--- a/src/model/UpdateOrderLineItemRequest.js
+++ b/src/model/UpdateOrderLineItemRequest.js
@@ -25,6 +25,20 @@ class UpdateOrderLineItemRequest {
         );
       }
 
+      if (data.hasOwnProperty('vintage_start_year')) {
+        obj['vintage_start_year'] = ApiClient.convertToType(
+          data['vintage_start_year'],
+          'Number'
+        );
+      }
+
+      if (data.hasOwnProperty('vintage_end_year')) {
+        obj['vintage_end_year'] = ApiClient.convertToType(
+          data['vintage_end_year'],
+          'Number'
+        );
+      }
+
       if (data.hasOwnProperty('price')) {
         obj['price'] = ApiClient.convertToType(data['price'], 'Number');
       }
@@ -46,6 +60,10 @@ class UpdateOrderLineItemRequest {
 }
 
 UpdateOrderLineItemRequest.prototype['vintage_year'] = undefined;
+
+UpdateOrderLineItemRequest.prototype['vintage_start_year'] = undefined;
+
+UpdateOrderLineItemRequest.prototype['vintage_end_year'] = undefined;
 
 UpdateOrderLineItemRequest.prototype['price'] = undefined;
 

--- a/test/integration/estimates.test.js
+++ b/test/integration/estimates.test.js
@@ -46,7 +46,7 @@ describe('Estimates Integration', function () {
     );
     const estimate = createEstimateResponse.data;
 
-    expect(estimate.type).to.be.eq('shipping');
+    expect(estimate.type).to.be.eq('ecommerce');
     expect(estimate.mass_g).to.be.above(0);
     expect(estimate.production).to.be.eq(false);
     expect(estimate.order).to.be.eq(null);

--- a/test/integration/projects.test.js
+++ b/test/integration/projects.test.js
@@ -41,6 +41,8 @@ describe('Project Integration', function () {
     const inventory = projectResponse.data.inventory;
     expect(inventory).to.be.a('array');
     expect(inventory[0].vintage_year).to.be.a('number');
+    expect(inventory[0].vintage_start_year).to.be.a('number');
+    expect(inventory[0].vintage_end_year).to.be.a('number');
     expect(inventory[0].amount_available).to.be.a('number');
     expect(inventory[0].price).to.be.a('number');
     expect(inventory[0].currency).to.be.a('string');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,9 +1236,9 @@
   "version" "6.2.0"
 
 "caniuse-lite@^1.0.30001274":
-  "integrity" "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA=="
-  "resolved" "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz"
-  "version" "1.0.30001341"
+  "integrity" "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g=="
+  "resolved" "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz"
+  "version" "1.0.30001469"
 
 "chai@^4.3.0":
   "integrity" "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA=="


### PR DESCRIPTION
### What

API version 2.1.0. See https://docs.patch.io/#/changelog for changes

### Why

Version 2.1.0 adds support for 
* `vintage_start_year` and `vintage_end_year` for orders
* `vintage_start_year` and `vintage_end_year` for  order line items
* `vintage_start_year` and `vintage_end_year` for  inventory
*  `carrier_scac` field to `patch.estimates.createRoadShippingEstimate`

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the library locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] ~If endpoints were removed, did you manually remove the corresponding files? (this should be rare)~
- [ ] ~For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?~
