### PR TITLE
Update to 2.1.1 for issuance_type and disclaimers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2023-04-18
+
+### Added
+
+- Adds `issuance_type` to `project` responses
+- Adds `disclaimers` to `project` responses
+
 ## [2.1.0] - 2023-04-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patch-technology/patch",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@patch-technology/patch",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "query-string": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patch-technology/patch",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Node.js wrapper for the Patch API",
   "license": "MIT",
   "repository": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -16,7 +16,7 @@ class ApiClient {
     };
 
     this.defaultHeaders = {
-      'User-Agent': 'patch-node/2.1.0',
+      'User-Agent': 'patch-node/2.1.1',
       'Patch-Version': 2
     };
 

--- a/src/model/Disclaimer.js
+++ b/src/model/Disclaimer.js
@@ -1,0 +1,61 @@
+/**
+ * Patch API V2
+ * The core API used to integrate with Patch's service
+ *
+ * Contact: engineering@usepatch.com
+ */
+
+import ApiClient from '../ApiClient';
+
+class Disclaimer {
+  constructor(header, severity) {
+    Disclaimer.initialize(this, header, severity);
+  }
+
+  static initialize(obj, header, severity) {
+    obj['header'] = header;
+    obj['severity'] = severity;
+  }
+
+  static constructFromObject(data, obj) {
+    if (data) {
+      obj = obj || new Disclaimer();
+
+      if (data.hasOwnProperty('body')) {
+        obj['body'] = ApiClient.convertToType(data['body'], 'String');
+      }
+
+      if (data.hasOwnProperty('header')) {
+        obj['header'] = ApiClient.convertToType(data['header'], 'String');
+      }
+
+      if (data.hasOwnProperty('severity')) {
+        obj['severity'] = ApiClient.convertToType(data['severity'], 'String');
+      }
+
+      if (data.hasOwnProperty('link_text')) {
+        obj['link_text'] = ApiClient.convertToType(data['link_text'], 'String');
+      }
+
+      if (data.hasOwnProperty('link_destination')) {
+        obj['link_destination'] = ApiClient.convertToType(
+          data['link_destination'],
+          'String'
+        );
+      }
+    }
+    return obj;
+  }
+}
+
+Disclaimer.prototype['body'] = undefined;
+
+Disclaimer.prototype['header'] = undefined;
+
+Disclaimer.prototype['severity'] = undefined;
+
+Disclaimer.prototype['link_text'] = undefined;
+
+Disclaimer.prototype['link_destination'] = undefined;
+
+export default Disclaimer;

--- a/src/model/Project.js
+++ b/src/model/Project.js
@@ -6,6 +6,7 @@
  */
 
 import ApiClient from '../ApiClient';
+import Disclaimer from './Disclaimer';
 import Highlight from './Highlight';
 import Inventory from './Inventory';
 import Photo from './Photo';
@@ -100,6 +101,13 @@ class Project {
         obj['state'] = ApiClient.convertToType(data['state'], 'String');
       }
 
+      if (data.hasOwnProperty('issuance_type')) {
+        obj['issuance_type'] = ApiClient.convertToType(
+          data['issuance_type'],
+          'String'
+        );
+      }
+
       if (data.hasOwnProperty('latitude')) {
         obj['latitude'] = ApiClient.convertToType(data['latitude'], 'Number');
       }
@@ -152,6 +160,12 @@ class Project {
           Inventory
         ]);
       }
+
+      if (data.hasOwnProperty('disclaimers')) {
+        obj['disclaimers'] = ApiClient.convertToType(data['disclaimers'], [
+          Disclaimer
+        ]);
+      }
     }
     return obj;
   }
@@ -170,6 +184,8 @@ Project.prototype['mechanism'] = undefined;
 Project.prototype['country'] = undefined;
 
 Project.prototype['state'] = undefined;
+
+Project.prototype['issuance_type'] = undefined;
 
 Project.prototype['latitude'] = undefined;
 
@@ -192,5 +208,7 @@ Project.prototype['technology_type'] = undefined;
 Project.prototype['highlights'] = undefined;
 
 Project.prototype['inventory'] = undefined;
+
+Project.prototype['disclaimers'] = undefined;
 
 export default Project;

--- a/test/integration/projects.test.js
+++ b/test/integration/projects.test.js
@@ -47,6 +47,17 @@ describe('Project Integration', function () {
     expect(inventory[0].price).to.be.a('number');
     expect(inventory[0].currency).to.be.a('string');
     expect(inventory[0].unit).to.be.a('string');
+
+    const issuance_type = projectResponse.data.issuance_type;
+    expect(issuance_type).to.be.a('string');
+
+    const disclaimers = projectResponse.data.disclaimers;
+    expect(disclaimers).to.be.a('array');
+    expect(disclaimers[0].header).to.be.a('string');
+    expect(disclaimers[0].body).to.be.a('string');
+    expect(disclaimers[0].severity).to.be.a('string');
+    expect(disclaimers[0].link_text).to.be.a('string');
+    expect(disclaimers[0].link_destination).to.be.a('string');
   });
 
   it('supports fetching a single project in a different language', async function () {


### PR DESCRIPTION
### What

- Adds `issuance_type` to `project` responses
- Adds `disclaimers` to `project` responses

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the package locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
~- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)~
~- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?~
